### PR TITLE
Removed obsolete catalog preset

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -14,10 +14,10 @@
 	<string>Terminal Module</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
-	<key>CFBundleVersion</key>
-	<string>11E</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>120</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2004, Blacktree, Inc.</string>
 	<key>QSActions</key>
@@ -226,36 +226,6 @@
 	</dict>
 	<key>QSPresetAdditions</key>
 	<array>
-		<dict>
-			<key>ID</key>
-			<string>QSPresetTerminalFiles</string>
-			<key>enabled</key>
-			<true/>
-			<key>icon</key>
-			<string>com.apple.Terminal</string>
-			<key>name</key>
-			<string>Terminal Files</string>
-			<key>requiresSettingsPath</key>
-			<true/>
-			<key>settings</key>
-			<dict>
-				<key>folderDepth</key>
-				<integer>1</integer>
-				<key>folderTypes</key>
-				<array>
-					<string>term</string>
-					<string>command</string>
-				</array>
-				<key>parser</key>
-				<string>QSDirectoryParser</string>
-				<key>path</key>
-				<string>~/Library/Application Support/Terminal</string>
-				<key>skipItem</key>
-				<true/>
-			</dict>
-			<key>source</key>
-			<string>QSFileSystemObjectSource</string>
-		</dict>
 		<dict>
 			<key>ID</key>
 			<string>QSPresetBashHistory</string>


### PR DESCRIPTION
Exactly what it says on the tin.

There was an old preset for ~/Library/Application Support/Terminal which used to contain old terminal settings files. Obsolete in 10.5+ systems
