### PR TITLE
	don't read the entire file into memory when checking for #! at the start

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>129</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2004, Blacktree, Inc.</string>
 	<key>QSActions</key>


### PR DESCRIPTION
Goes alongside quicksilver/quicksilver#1026

Unfortunately, the QSShellScriptRunAction.m file is not in any external frameworks, so the existing `BOOL QSPathCanBeExecuted(NSString *path, BOOL allowApps)` method there cannot be used.

This code is (almost) an identical copy/paste of that method
