### PR TITLE
Update actions to work with UTIs (QS v1.2+)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>147</string>
+	<string>14A</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2004, Blacktree, Inc.</string>
 	<key>QSActions</key>
@@ -32,9 +32,15 @@
 			<string>executeText:</string>
 			<key>description</key>
 			<string>Run a Text Command in Shell</string>
+			<key>directFileTypes</key>
+			<array>
+				<string>public.executable</string>
+				<string>public.script</string>
+			</array>
 			<key>directTypes</key>
 			<array>
-				<string>NSStringPboardType</string>
+				<string>public.utf8-plain-text</string>
+				<string>public.data</string>
 			</array>
 			<key>displaysResult</key>
 			<true/>
@@ -54,6 +60,13 @@
 			<key>directTypes</key>
 			<array>
 				<string>qs.shellcommand</string>
+				<string>public.utf8-plain-text</string>
+				<string>public.data</string>
+			</array>
+			<key>directFileTypes</key>
+			<array>
+				<string>public.executable</string>
+				<string>public.script</string>
 			</array>
 			<key>icon</key>
 			<string>TerminalIcon</string>
@@ -66,11 +79,17 @@
 		<dict>
 			<key>actionClass</key>
 			<string>QSCLExecutableProvider</string>
+			<key>directFileTypes</key>
+			<array>
+				<string>public.executable</string>
+				<string>public.script</string>
+			</array>
 			<key>actionSelector</key>
 			<string>executeTextInTerminal:</string>
 			<key>directTypes</key>
 			<array>
-				<string>NSStringPboardType</string>
+				<string>public.utf8-plain-text</string>
+				<string>public.executable</string>
 			</array>
 			<key>icon</key>
 			<string>TerminalIcon</string>
@@ -85,30 +104,23 @@
 			<string>executeObjectInTerm:arguments:</string>
 			<key>description</key>
 			<string>Run a Shell Script in the Terminal [with optional arguments]</string>
-			<key>directFileTypes</key>
-			<array>
-				<string>public.executable</string>
-				<string>public.script</string>
-				<string>sh</string>
-				<string>command</string>
-				<string>php</string>
-				<string>pl</string>
-				<string>py</string>
-				<string>rb</string>
-				<string></string>
-			</array>
 			<key>directTypes</key>
 			<array>
-				<string>NSFilenamesPboardType</string>
+				<string>public.data</string>
 			</array>
 			<key>icon</key>
 			<string>TerminalIcon</string>
 			<key>indirectOptional</key>
 			<true/>
+			<key>directFileTypes</key>
+			<array>
+				<string>public.executable</string>
+				<string>public.script</string>
+			</array>
 			<key>name</key>
 			<string>Run in Terminal […]</string>
 			<key>rankModification</key>
-			<real>2.0</real>
+			<real>2</real>
 			<key>validatesObjects</key>
 			<true/>
 		</dict>
@@ -120,7 +132,7 @@
 			<string>showParentDirectoryInTerminal:</string>
 			<key>directTypes</key>
 			<array>
-				<string>NSFilenamesPboardType</string>
+				<string>public.data</string>
 			</array>
 			<key>icon</key>
 			<string>TerminalIcon</string>
@@ -137,14 +149,16 @@
 			<string>showDirectoryInTerminal:</string>
 			<key>directTypes</key>
 			<array>
-				<string>NSFilenamesPboardType</string>
+				<string>public.data</string>
 			</array>
 			<key>icon</key>
 			<string>TerminalIcon</string>
+			<key>directFileTypes</key>
+			<array>
+				<string>public.directory</string>
+			</array>
 			<key>name</key>
 			<string>Open Directory in Terminal</string>
-			<key>validatesObjects</key>
-			<true/>
 		</dict>
 		<key>QSCLTermShowManPageAction</key>
 		<dict>
@@ -154,13 +168,12 @@
 			<string>showManPage:</string>
 			<key>directFileTypes</key>
 			<array>
-				<string></string>
 				<string>public.executable</string>
 				<string>public.script</string>
 			</array>
 			<key>directTypes</key>
 			<array>
-				<string>NSFilenamesPboardType</string>
+				<string>public.data</string>
 			</array>
 			<key>icon</key>
 			<string>TerminalIcon</string>
@@ -179,19 +192,12 @@
 			<string>Run a Shell Script [with optional arguments]</string>
 			<key>directFileTypes</key>
 			<array>
-				<string>public.script</string>
 				<string>public.executable</string>
-				<string>sh</string>
-				<string>pl</string>
-				<string>command</string>
-				<string>php</string>
-				<string>py</string>
-				<string>rb</string>
-				<string></string>
+				<string>public.script</string>
 			</array>
 			<key>directTypes</key>
 			<array>
-				<string>NSFilenamesPboardType</string>
+				<string>public.data</string>
 			</array>
 			<key>displaysResult</key>
 			<true/>
@@ -202,7 +208,7 @@
 			<key>name</key>
 			<string>Run […]</string>
 			<key>rankModification</key>
-			<real>2.0</real>
+			<real>2</real>
 			<key>validatesObjects</key>
 			<true/>
 		</dict>
@@ -224,20 +230,20 @@
 &lt;p&gt;The Terminal plugin allows Quicksilver to interact with the OS X Terminal; run commands and shell scripts, open directories in Terminal and more.&lt;/p&gt;
 &lt;h3&gt;Actions&lt;/h3&gt;
 &lt;p&gt;&lt;strong&gt; Run […]&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;This action takes any script in Quicksilver's first pane (.sh, .pl, .command, .php, .py, .rb) and runs it in a Shell. An indirect argument is optional, meaning you can run any script with an argument by inputting text in Quicksilver's third pane. This differs from the 'Run in Terminal […]' action in that it runs the script in a Shell, without opening a new Terminal window.&lt;/p&gt;
+&lt;p&gt;This action takes any script in Quicksilver&apos;s first pane (.sh, .pl, .command, .php, .py, .rb) and runs it in a Shell. An indirect argument is optional, meaning you can run any script with an argument by inputting text in Quicksilver&apos;s third pane. This differs from the &apos;Run in Terminal […]&apos; action in that it runs the script in a Shell, without opening a new Terminal window.&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;Run in Terminal […]&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;The Run in Terminal […] action can be used on script files (for example, php, pl, sh, py files) to run these files as scripts in a new Terminal window. The action supports an optional extra argument, entered in Quicksilver's 3rd pane. This differs from the 'run […]' action in that it opens a Terminal window, as opposed to running the script in a Shell.&lt;/p&gt;
+&lt;p&gt;The Run in Terminal […] action can be used on script files (for example, php, pl, sh, py files) to run these files as scripts in a new Terminal window. The action supports an optional extra argument, entered in Quicksilver&apos;s 3rd pane. This differs from the &apos;run […]&apos; action in that it opens a Terminal window, as opposed to running the script in a Shell.&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;Run Command in Shell&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;Runs the item in Quicksilver's first pane in a shell, without launching Terminal. The item in Quicksilver's first pane should be a string (entered in Text Mode) of your desired command. If the command returns an item (for example, &lt;code&gt;ls&lt;/code&gt; returns a list of files and folders) they are returned to Quicksilver as text.&lt;/p&gt;
+&lt;p&gt;Runs the item in Quicksilver&apos;s first pane in a shell, without launching Terminal. The item in Quicksilver&apos;s first pane should be a string (entered in Text Mode) of your desired command. If the command returns an item (for example, &lt;code&gt;ls&lt;/code&gt; returns a list of files and folders) they are returned to Quicksilver as text.&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;Run a Text Command in Terminal&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;Similar to the 'Run Command in Shell' action, but opens a new Terminal window and runs the command in the new window.&lt;/p&gt;
+&lt;p&gt;Similar to the &apos;Run Command in Shell&apos; action, but opens a new Terminal window and runs the command in the new window.&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;Open Directory in Terminal, Open Parent Directory in Terminal&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;These two actions open the folder or file selected in Quicksilver's first pane in Terminal. The name of the action depends on whether a folder or file is selected in Quicksilver's first pane.&lt;/p&gt;
+&lt;p&gt;These two actions open the folder or file selected in Quicksilver&apos;s first pane in Terminal. The name of the action depends on whether a folder or file is selected in Quicksilver&apos;s first pane.&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;Show Man Page&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;The 'Show Man Page' action can be run on any executable file (typically found in &lt;code&gt;/usr/bin&lt;/code&gt; or &lt;code&gt;/usr/local/bin&lt;/code&gt;). It opens a new window with the 'man' page for the selected executable.&lt;/p&gt;
+&lt;p&gt;The &apos;Show Man Page&apos; action can be run on any executable file (typically found in &lt;code&gt;/usr/bin&lt;/code&gt; or &lt;code&gt;/usr/local/bin&lt;/code&gt;). It opens a new window with the &apos;man&apos; page for the selected executable.&lt;/p&gt;
 &lt;h3&gt;Catalog Preset&lt;/h3&gt;
 &lt;p&gt;&lt;strong&gt;Bash Command History&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;This &lt;a href="qs://preferences#QSCatalogPrefPane"&gt;Catalog&lt;/a&gt; Preset, found under 'Plugins &amp;gt; Bash Command History' adds your bash history to the Quicksilver catalog (more accurately, it adds the contents of &lt;code&gt;~/.bash_history&lt;/code&gt; to your catalog).&lt;/p&gt;</string>
+&lt;p&gt;This &lt;a href=&quot;qs://preferences#QSCatalogPrefPane&quot;&gt;Catalog&lt;/a&gt; Preset, found under &apos;Plugins &amp;gt; Bash Command History&apos; adds your bash history to the Quicksilver catalog (more accurately, it adds the contents of &lt;code&gt;~/.bash_history&lt;/code&gt; to your catalog).&lt;/p&gt;</string>
 		<key>icon</key>
 		<string>com.apple.Terminal</string>
 		<key>relatedPaths</key>
@@ -309,7 +315,7 @@
 	<key>QSRequirements</key>
 	<dict>
 		<key>version</key>
-		<string>4001</string>
+		<string>400E</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes quicksilver/quicksilver#1962

Just changed the 'Run command in Shell' action to accept scripts, (and the other actions to use UTIs) then updated the plugin to be 1.2.0+ only
