### PR TITLE
Make the 'Run a Text Command in Terminal' action only work on text

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>14C</string>
+	<string>14D</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2004, Blacktree, Inc.</string>
 	<key>QSActions</key>
@@ -70,15 +70,9 @@
 			<string>QSCLExecutableProvider</string>
 			<key>actionSelector</key>
 			<string>executeTextInTerminal:</string>
-			<key>directFileTypes</key>
-			<array>
-				<string>public.executable</string>
-				<string>public.script</string>
-			</array>
 			<key>directTypes</key>
 			<array>
 				<string>public.utf8-plain-text</string>
-				<string>public.executable</string>
 			</array>
 			<key>icon</key>
 			<string>TerminalIcon</string>


### PR DESCRIPTION
It should never have been used for other files. The use in quicksilver/quicksilver#1962 was using a bug in pre 1.2 Quicksilver (quicksilver/quicksilver#1804) to get this to work, and it should never have been possible.

If we want to make a 'one action fits all' called "run command in terminal" then we could do that but then it'd be more complicated how we support the optional 3rd pane args for shell commands
